### PR TITLE
Feat : 칼럼 확장

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 
 node_modules
+/node_modules
+node_modules/*
 dist
 dist-ssr
 *.local

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,6 @@
+.container {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 10px;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,53 +1,16 @@
-import React, { useCallback, useState } from 'react';
-import { DragDropContext, Droppable, DropResult } from 'react-beautiful-dnd';
-import type { itemTypes } from '@type/index';
-import { getItems } from '@util/index';
-import { GRID } from '@constant/index';
-import Atom from '@component/atom';
+import React from 'react';
+import { DndProvider } from '@store/context/dndContext';
+import './App.css';
+import Table from './container';
 
 function App() {
-  const [items, setItems] = useState<itemTypes[]>(getItems(10));
-
-  const reorder = (list: itemTypes[], startIndex: number, endIndex: number) => {
-    const result = Array.from(list);
-    const [removed] = result.splice(startIndex, 1);
-    result.splice(endIndex, 0, removed);
-    return result;
-  };
-
-  const onDragEnd = useCallback(
-    (result: DropResult) => {
-      if (!result.destination) {
-        return;
-      }
-
-      const newItems = reorder(items, result.source.index, result.destination.index);
-
-      setItems(newItems);
-    },
-    [items],
-  );
-
   return (
-    <DragDropContext onDragEnd={onDragEnd}>
-      <Droppable droppableId="droppable">
-        {(provided, snapshot) => (
-          <div {...provided.droppableProps} ref={provided.innerRef} style={getListStyle(snapshot.isDraggingOver)}>
-            {items.map((item, index) => (
-              <Atom item={item} index={index} />
-            ))}
-            {provided.placeholder}
-          </div>
-        )}
-      </Droppable>
-    </DragDropContext>
+    <div className="container">
+      <DndProvider itemCnt={4}>
+        <Table />
+      </DndProvider>
+    </div>
   );
 }
-
-const getListStyle = (isDraggingOver: boolean) => ({
-  background: isDraggingOver ? 'lightblue' : 'lightgrey',
-  padding: GRID,
-  width: 250,
-});
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,11 @@
-import React, { DetailedHTMLProps, HTMLAttributes } from 'react';
-import { useCallback, useState } from 'react';
-import {
-  DragDropContext,
-  Droppable,
-  Draggable,
-  DraggingStyle,
-  NotDraggingStyle,
-  DropResult,
-} from 'react-beautiful-dnd';
-import { itemTypes } from './type';
+import React, { useCallback, useState } from 'react';
+import { DragDropContext, Droppable, DropResult } from 'react-beautiful-dnd';
+import type { itemTypes } from '@type/index';
+import { getItems } from '@util/index';
+import { GRID } from '@constant/index';
+import Atom from '@component/atom';
 
 function App() {
-  const getItems = (count: number): itemTypes[] =>
-    Array.from({ length: count }, (_, k) => k).map((k) => ({
-      id: `item-${k}`,
-      content: `item ${k}`,
-    }));
-
   const [items, setItems] = useState<itemTypes[]>(getItems(10));
 
   const reorder = (list: itemTypes[], startIndex: number, endIndex: number) => {
@@ -36,7 +25,7 @@ function App() {
 
       setItems(newItems);
     },
-    [items]
+    [items],
   );
 
   return (
@@ -45,23 +34,7 @@ function App() {
         {(provided, snapshot) => (
           <div {...provided.droppableProps} ref={provided.innerRef} style={getListStyle(snapshot.isDraggingOver)}>
             {items.map((item, index) => (
-              <Draggable key={item.id} draggableId={item.id} index={index}>
-                {(provided, snapshot) => (
-                  <div
-                    ref={provided.innerRef}
-                    {...provided.draggableProps}
-                    {...provided.dragHandleProps}
-                    style={
-                      getItemStyle(snapshot.isDragging, provided.draggableProps.style) as DetailedHTMLProps<
-                        HTMLAttributes<HTMLDivElement>,
-                        HTMLDivElement
-                      >
-                    }
-                  >
-                    {item.content}
-                  </div>
-                )}
-              </Draggable>
+              <Atom item={item} index={index} />
             ))}
             {provided.placeholder}
           </div>
@@ -70,16 +43,6 @@ function App() {
     </DragDropContext>
   );
 }
-
-const GRID = 8;
-
-const getItemStyle = (isDragging: boolean, draggableStyle?: DraggingStyle | NotDraggingStyle) => ({
-  userSelect: 'none',
-  padding: GRID * 2,
-  margin: `0 0 ${GRID}px 0`,
-  background: isDragging ? 'lightgreen' : 'grey',
-  ...draggableStyle,
-});
 
 const getListStyle = (isDraggingOver: boolean) => ({
   background: isDraggingOver ? 'lightblue' : 'lightgrey',

--- a/src/component/atom.tsx
+++ b/src/component/atom.tsx
@@ -1,0 +1,41 @@
+import { GRID } from '@constant/index';
+import { itemTypes } from '@type/index';
+import React, { DetailedHTMLProps, HTMLAttributes } from 'react';
+import { Draggable, DraggingStyle, NotDraggingStyle } from 'react-beautiful-dnd';
+
+interface AtomProps {
+  item: itemTypes;
+  index: number;
+}
+
+function Atom({ item, index }: AtomProps) {
+  return (
+    <Draggable key={item.id} draggableId={item.id} index={index}>
+      {(provided, snapshot) => (
+        <div
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+          style={
+            getItemStyle(snapshot.isDragging, provided.draggableProps.style) as DetailedHTMLProps<
+              HTMLAttributes<HTMLDivElement>,
+              HTMLDivElement
+            >
+          }
+        >
+          {item.content}
+        </div>
+      )}
+    </Draggable>
+  );
+}
+
+export default Atom;
+
+const getItemStyle = (isDragging: boolean, draggableStyle?: DraggingStyle | NotDraggingStyle) => ({
+  userSelect: 'none',
+  padding: GRID * 2,
+  margin: `0 0 ${GRID}px 0`,
+  background: isDragging ? 'lightgreen' : 'grey',
+  ...draggableStyle,
+});

--- a/src/component/atom.tsx
+++ b/src/component/atom.tsx
@@ -1,9 +1,9 @@
-import { GRID } from '@constant/index';
-import { itemTypes } from '@type/index';
 import React, { DetailedHTMLProps, HTMLAttributes } from 'react';
+import { GRID } from '@constant/index';
+import type { itemTypes } from '@type/index';
 import { Draggable, DraggingStyle, NotDraggingStyle } from 'react-beautiful-dnd';
 
-interface AtomProps {
+export interface AtomProps {
   item: itemTypes;
   index: number;
 }

--- a/src/component/modules.tsx
+++ b/src/component/modules.tsx
@@ -1,0 +1,32 @@
+import React, { PropsWithChildren, ReactElement, cloneElement } from 'react';
+import { Droppable } from 'react-beautiful-dnd';
+import { GRID } from '@constant/index';
+import { useDnd } from '@store/context/dndContext';
+import { AtomProps } from './atom';
+
+interface ModulesProps extends PropsWithChildren {
+  children: ReactElement<AtomProps>;
+}
+
+function Modules({ children }: ModulesProps) {
+  const { items } = useDnd();
+
+  return (
+    <Droppable droppableId="droppable">
+      {(provided, snapshot) => (
+        <div {...provided.droppableProps} ref={provided.innerRef} style={getListStyle(snapshot.isDraggingOver)}>
+          {items.map((item, index) => cloneElement(children, { item: item, index: index }))}
+          {provided.placeholder}
+        </div>
+      )}
+    </Droppable>
+  );
+}
+
+export default Modules;
+
+const getListStyle = (isDraggingOver: boolean) => ({
+  background: isDraggingOver ? 'lightblue' : 'lightgrey',
+  padding: GRID,
+  width: 250,
+});

--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -1,0 +1,1 @@
+export const GRID = 8;

--- a/src/container/index.tsx
+++ b/src/container/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import Modules from '@component/modules';
+import Column from '@layout/column';
+import { DndProvider, useDnd } from '@store/context/dndContext';
+import Atom from '@component/atom';
+
+function Table() {
+  const { items } = useDnd();
+
+  return (
+    <Column>
+      {items.map(() => (
+        <Column>
+          <DndProvider itemCnt={10}>
+            <Modules>
+              <Atom item={{ id: '', content: '' }} index={0} />
+            </Modules>
+          </DndProvider>
+        </Column>
+      ))}
+    </Column>
+  );
+}
+
+export default Table;

--- a/src/layout/column.tsx
+++ b/src/layout/column.tsx
@@ -1,0 +1,12 @@
+import React, { PropsWithChildren } from 'react';
+import { DragDropContext } from 'react-beautiful-dnd';
+import { useDnd } from '@store/context/dndContext';
+
+interface ColumnProps extends PropsWithChildren {}
+
+function Column({ children }: ColumnProps) {
+  const { onDragEnd } = useDnd();
+  return <DragDropContext onDragEnd={onDragEnd}>{children}</DragDropContext>;
+}
+
+export default Column;

--- a/src/store/context/dndContext.tsx
+++ b/src/store/context/dndContext.tsx
@@ -1,0 +1,37 @@
+import React, { FunctionComponent, createContext, useCallback, useContext, useState } from 'react';
+import { getItems } from '@util/index';
+import { DropResult } from 'react-beautiful-dnd';
+import type { itemTypes } from '@type/index';
+import { DndContextValues, type DndProviderParam } from '@type/context';
+
+export const DndContext = createContext<DndContextValues | {}>({});
+
+export const DndProvider: FunctionComponent<DndProviderParam> = ({ children, itemCnt }) => {
+  const [items, setItems] = useState<itemTypes[]>(getItems(itemCnt));
+
+  const reorder = (list: itemTypes[], startIndex: number, endIndex: number) => {
+    const result = Array.from(list);
+    const [removed] = result.splice(startIndex, 1);
+    result.splice(endIndex, 0, removed);
+    return result;
+  };
+
+  const onDragEnd = useCallback(
+    (result: DropResult) => {
+      if (!result.destination) {
+        return;
+      }
+
+      const newItems = reorder(items, result.source.index, result.destination.index);
+
+      setItems(newItems);
+    },
+    [items],
+  );
+
+  return <DndContext.Provider value={{ items, setItems, onDragEnd }}>{children}</DndContext.Provider>;
+};
+
+export const useDnd = (): DndContextValues => {
+  return useContext(DndContext) as DndContextValues;
+};

--- a/src/type/context.d.ts
+++ b/src/type/context.d.ts
@@ -1,0 +1,13 @@
+import { PropsWithChildren, Dispatch, SetStateAction } from 'react';
+import { itemTypes } from '.';
+import { DropResult } from 'react-beautiful-dnd';
+
+export interface DndProviderParam extends PropsWithChildren {
+  itemCnt: number;
+}
+
+export interface DndContextValues {
+  items: itemTypes[];
+  setItems: Dispatch<SetStateAction<itemTypes[]>>;
+  onDragEnd: (result: DropResult) => void;
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,0 +1,7 @@
+import type { itemTypes } from '@type/index';
+
+export const getItems = (count: number): itemTypes[] =>
+  Array.from({ length: count }, (_, k) => k).map((k) => ({
+    id: `item-${k}`,
+    content: `item ${k}`,
+  }));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,4 +33,20 @@ module.exports = {
   devServer: {
     port: 3000,
   },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js', '.jsx'],
+    modules: [path.resolve(__dirname, 'src'), 'node_modules'],
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+      '@constant': path.resolve(__dirname, './src/constant'),
+      '@component': path.resolve(__dirname, './src/component'),
+      '@container': path.resolve(__dirname, './src/container'),
+      '@api': path.resolve(__dirname, './src/api'),
+      '@hooks': path.resolve(__dirname, './src/hooks'),
+      '@store': path.resolve(__dirname, './src/store'),
+      '@util': path.resolve(__dirname, './src/util'),
+      '@layout': path.resolve(__dirname, './src/layout'),
+      '@type': path.resolve(__dirname, './src/type'),
+    },
+  },
 };


### PR DESCRIPTION
## 요약
기존 하나였던 칼럼을 4개로 확장

## 내용
- 칼럼 확장을 위해 기존 App.tsx 코드를 atom, modules, container 등으로 분리
- contextAPI를 통해 dnd 함수를 자유롭게 쓸 수 있도록 메소드 분리

## 고려 사항
- 현재 칼럼 간 Dnd 되지 않는 현상
- Dnd 도중 칼럼이 추가되는 현상